### PR TITLE
fix #74 - `gulp watch` should also watch tests (recompile and run the…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,6 +91,7 @@ gulp.task('test-no-compile', function (done) {
 
 gulp.task('watch', ['test'], function () {
     gulp.watch(paths.source + '**/*.ts', ['test']);
+    gulp.watch(paths.spec + '**/*spec.ts', ['test']);
 });
 
 gulp.task('default', ['test'], function () {


### PR DESCRIPTION
…m when tests change)