### PR TITLE
fix #101 - add gulp tasks for formatting TS sources (format:sources) …

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,6 +10,8 @@ var sourcemap = require('gulp-sourcemaps');
 var rimraf = require('gulp-rimraf');
 var replace = require('gulp-replace');
 var runsequence = require('run-sequence');
+var tslint = require('gulp-tslint');
+var typescriptFormatter = require('gulp-typescript-formatter');
 
 var paths = {
     source: "source/",
@@ -29,8 +31,6 @@ gulp.task('clean:tests', function () {
 
 gulp.task('clean', ['clean:tests', 'clean:typescript'], function () {
 });
-
-var tslint = require('gulp-tslint');
 
 gulp.task('compile:typescript', ['clean:typescript'], function () {
     var project = ts.createProject('tsconfig.json', {
@@ -61,6 +61,25 @@ gulp.task('lint:typescript', function() {
       formatter: "verbose"
     }))
     .pipe(tslint.report());
+});
+
+function format(sourcePattern, targetDir) {
+    return gulp.src(sourcePattern)
+        .pipe(typescriptFormatter({
+            baseDir: '.',
+            tslint: true, // use tslint.json file ?
+            editorconfig: true, // use .editorconfig file ?
+            tsfmt: true, // use tsfmt.json ?
+        }))
+        .pipe(gulp.dest(targetDir));
+}
+
+gulp.task('format:sources', function () {
+    return format(paths.source + '**/*.ts', paths.source);
+});
+
+gulp.task('format:tests', function () {
+    return format(paths.spec + '**/*.ts', paths.spec);
 });
 
 gulp.task('compile:tests', ['compile:typescript', 'clean:tests'], function () {

--- a/package.json
+++ b/package.json
@@ -38,9 +38,11 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^6.0.2",
     "gulp-typescript": "^2.13.6",
+    "gulp-typescript-formatter": "^0.1.1",
     "merge2": "^1.0.2",
     "run-sequence": "^1.2.1",
     "tslint": "^3.14.0",
+    "typescript-formatter": "^2.3.0",
     "typings": "^1.0.4"
   },
   "scripts": {


### PR DESCRIPTION
…and tests(format:tests) - useful for #98 (review linting rules in tslint.json) and #100 (review editorconfig rules in .editorconfig)